### PR TITLE
Feature/cd action

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,59 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: CD
+
+on:
+    push:
+        branches:
+            - '**'
+#   release:
+#     types: [published]
+
+jobs:
+  build_package:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build Package
+        run: python -m build --wheel
+
+      - name: Upload wheels to artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist/*
+
+#   pypi-publish:
+#     name: Upload release to PyPI
+#     needs: build_package
+#     runs-on: ubuntu-latest
+#     environment:
+#       name: pypi
+#       url: https://pypi.org/p/pycifrw/
+#     permissions:
+#       id-token: write
+#     steps:
+#       - uses: actions/download-artifact@v3
+#         with:
+#           name: wheels
+#           path: dist
+
+#       - name: check the dist folder
+#         run: ls dist
+
+#       - name: Publish to PyPI
+#         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          pip install setuptools wheel build
 
       - name: Build Package
         run: python -m build --wheel

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+
       - name: Build Package
         run: python -m build --wheel
 


### PR DESCRIPTION
This Pull request adds a github action to create wheels for all operation systems: MacOS, Linux and Windows for Python versions 3.9 to 3.12. It tries to address issue #9.

The generated wheels are downloadable as an artifact and could uploaded to pypi manually. 

Additionally, there is a section which can be uncommented to do this automatically after a release. However, to use this efficiently, pycifrw would need to use git tags for releases and the github release.